### PR TITLE
input.type = 'number' throws exception in IE9

### DIFF
--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -38,22 +38,22 @@ function addDocumentListeners(doc) {
         documentInput({target: document.activeElement}); // selectionchange evts don't have the e.target we need
       }
     }, true);
-  }
-
-  // For some reason valueAsNumber returns NaN for number inputs in IE
-  // until a new IE version that handles this is released, parse input.value as a fallback
-  var input = document.createElement('input');
-  input.type = 'number';
-  input.value = '7';
-  if (input.valueAsNumber !== input.valueAsNumber) {
-    var oldInputValue = inputValue;
-    inputValue = function(input) {
-      if (input.type === 'number') {
-        return inputIsNumberValue(input) ? parseFloat(input.value) : input.value;
-      } else {
-        return oldInputValue.apply(this, arguments);
-      }
-    };
+  } else { //cannot set input.type to 'number' in IE9
+    // For some reason valueAsNumber returns NaN for number inputs in IE
+    // until a new IE version that handles this is released, parse input.value as a fallback
+    var input = document.createElement('input');
+    input.type = 'number';
+    input.value = '7';
+    if (input.valueAsNumber !== input.valueAsNumber) {
+      var oldInputValue = inputValue;
+      inputValue = function(input) {
+        if (input.type === 'number') {
+          return inputIsNumberValue(input) ? parseFloat(input.value) : input.value;
+        } else {
+          return oldInputValue.apply(this, arguments);
+        }
+      };
+    }
   }
 }
 


### PR DESCRIPTION
the line `input.type = 'number'` in IE9 and older throws an exception and therefore stops all javascript execution. 
This patch doesn't fix "input type number" on those old browsers, but at least it doesn't blow up everything like it does now.
